### PR TITLE
Add mobile redirect URI to OIDC guide

### DIFF
--- a/content/guides/11.sso_configuration.md
+++ b/content/guides/11.sso_configuration.md
@@ -90,6 +90,7 @@ identity_providers:
         public: false
         redirect_uris:
           - https://your.audiobookshelf.instance.com/auth/openid/callback
+          - https://your.audiobookshelf.instance.com/auth/openid/mobile-redirect
         scopes:
           - openid
           - profile


### PR DESCRIPTION
This additional URL is required for OIDC authentication in the mobile app. It was added in https://github.com/advplyr/audiobookshelf/pull/2386