### PR TITLE
Simplify example OIDC configuration for Authelia

### DIFF
--- a/content/guides/11.sso_configuration.md
+++ b/content/guides/11.sso_configuration.md
@@ -56,38 +56,17 @@ The steps needed to configure an OIDC provider will vary depending on which OIDC
 
 ## Authelia
 
-Configuring Authelia as an OIDC provider is covered well in the [authelia docs](https://www.authelia.com/configuration/identity-providers/open-id-connect/), which should be treated as the source of truth. An example authelia configuration that is known to work is provided for reference.
-
-Add the following to the authelia `configuration.yml` file:
+Configuring Authelia as an OIDC provider is covered well in the [authelia docs](https://www.authelia.com/configuration/identity-providers/open-id-connect/) The sample configuration below only includes the details required to configure Audiobookshelf as a client:
 
 ``` yaml
 identity_providers:
   oidc:
-    hmac_secret: your_hmac_secret
-    issuer_private_key: |
-      -----BEGIN RSA PRIVATE KEY-----
-      ... your private key here ...
-      -----END RSA PRIVATE KEY-----
-    access_token_lifespan: 7d
-    authorize_code_lifespan: 1m
-    id_token_lifespan: 7d
-    refresh_token_lifespan: 90m
-    enable_client_debug_messages: false
-    enforce_pkce: public_clients_only
-    cors:
-      endpoints:
-        - authorization
-        - token
-        - revocation
-        - introspection
-      allowed_origins:
-        - https://your.audiobookshelf.instance.com
-      allowed_origins_from_client_redirect_uris: false
+    # See the Authelia documentation for additional configuration required to get OIDC working. Only the audiobookshelf client configuration is included here
+    # https://www.authelia.com/configuration/identity-providers/open-id-connect/
     clients:
       - id: audiobookshelf # this must match the client id provided to audiobookshelf
         description: "Audiobookshelf"
         secret: 'your_client_secret' # this must match the client secret provided to audiobookshelf
-        public: false
         redirect_uris:
           - https://your.audiobookshelf.instance.com/auth/openid/callback
         scopes:


### PR DESCRIPTION
This may be a controversial change since the example configuration is no longer a full working example. However, the existing example was not secure and a user copy/pasting the example without paying attention would end up with an insecure configuration. Someone setting this up should be forced to go to the Authelia documentation and read through what all the settings mean.

In addition, the settings I have removed from the example are all either unnecessary to specify, or should be specified using a secret instead of an inline value. My own personal working configuration actually does match the new example as shown, because the other settings that are required to be specified are done so via secrets.